### PR TITLE
Bug/performance fixes in sudoko.py:

### DIFF
--- a/sudoku.py
+++ b/sudoku.py
@@ -38,8 +38,8 @@ def eliminate_candidates(board, groups=groups):
 def solve(board):
     candidates, prev = 1 + 9**3, 2 + 9**3
     while 81 < candidates < prev:  # keep eliminating
-        prev, candidates = candidates, sum(map(len, board))
         eliminate_candidates(board)
+        prev, candidates = candidates, sum(map(len, board))
     if candidates == 81:  # we're done!
         return board
     lengths = map(len, board)  # otherwise, we need to search
@@ -54,6 +54,6 @@ def solve(board):
 
 if __name__ == '__main__':
     if len(sys.argv) == 2: sudoku = sys.argv[1]
-    board = list(islice([c if c.isdigit() else '123456789' for c in sudoku if c.isdigit() or c in '.0'], 81))
+    board = list(islice((c if c in '123456789' else '123456789' for c in sudoku if c in '123456789.0'), 81))
     line, div = ' {} {} {} | {} {} {} | {} {} {} \n', '-------+-------+-------\n'
     print (line * 3 + div + line * 3 + div + line * 3).format(*solve(board))


### PR DESCRIPTION
Bug/performance fixes in sudoko.py:

1. Input parsing was botching handling of '0'
   (which presumably is supposed to mean the same thing as '.').
   To demonstrate (before this commit):
     python2 sudoku.py 1.....7....71.9...68..7......1.9.6.....3...2..4......3..8.6.1..5......4......2.05
   Notice the output contains a 0, which makes no sense.

2. Input parsing was doing islice on a list comprehension,
   which is pointless; changed it to do the islice on a
   generator expression instead, as intended.

3. The updating of prev,candidates was in the wrong place:
   it should be done after updating the board, not before it.
   Fixing this reduces unnecessary calls to eliminate_candidates,
   which improves the running time on my machine
   from 5.6s down to 3.8s for the default (Everest) board,
   and from 14s down to 10s for the "difficulty: off charts :)" example
   from collections/test_db.txt; that is:
     python2 sudoku.py 1.....7....71.9...68..7......1.9.6.....3...2..4......3..8.6.1..5......4......2..5

====================================================
Note: The above description is from the second commit d04bd94 of this pull request; the first commit 80fd632 is a previous pull request https://github.com/r1cc4rdo/sudoku/pull/2 which should be pulled first (if it's acceptable).  I'm not sure I'm managing these dependent pull requests properly.


