### PR TITLE
Print number of calls to solve() at end. 

### DIFF
--- a/sudoku.py
+++ b/sudoku.py
@@ -35,7 +35,9 @@ def eliminate_candidates(board, groups=groups):
                     assert board[index]  # if triggered, inconsistent assignment detected
 
 
+num_solves = 0
 def solve(board):
+    global num_solves; num_solves += 1
     candidates, prev = 1 + 9**3, 2 + 9**3
     while 81 < candidates < prev:  # keep eliminating
         prev, candidates = candidates, sum(map(len, board))
@@ -57,3 +59,4 @@ if __name__ == '__main__':
     board = list(islice([c if c.isdigit() else '123456789' for c in sudoku if c.isdigit() or c in '.0'], 81))
     line, div = ' {} {} {} | {} {} {} | {} {} {} \n', '-------+-------+-------\n'
     print (line * 3 + div + line * 3 + div + line * 3).format(*solve(board))
+    print "num_solves = %r" % (num_solves,)

--- a/sudoku.py
+++ b/sudoku.py
@@ -35,9 +35,8 @@ def eliminate_candidates(board, groups=groups):
                     assert board[index]  # if triggered, inconsistent assignment detected
 
 
-num_solves = 0
-def solve(board):
-    global num_solves; num_solves += 1
+def solve(board, num_solves):
+    num_solves[0] += 1
     candidates, prev = 1 + 9**3, 2 + 9**3
     while 81 < candidates < prev:  # keep eliminating
         eliminate_candidates(board)
@@ -48,7 +47,7 @@ def solve(board):
     pivot = lengths.index(sorted(set(lengths))[1])
     for board[pivot] in board[pivot]:
         try:
-            return solve(board[:])
+            return solve(board[:], num_solves)
         except AssertionError as e:
             pass  # try next element
     raise AssertionError('No solutions found')  # keep searching in caller
@@ -59,5 +58,6 @@ if __name__ == '__main__':
         sudoku = ' '.join(sys.argv[1:])
     board = list(islice((c if c in '123456789' else '123456789' for c in sudoku if c in '0123456789.'), 81))
     line, div = ' {} {} {} | {} {} {} | {} {} {} \n', '-------+-------+-------\n'
-    print (line * 3 + div + line * 3 + div + line * 3).format(*solve(board))
-    print "num_solves = %r" % (num_solves,)
+    num_solves = [0]
+    print (line * 3 + div + line * 3 + div + line * 3).format(*solve(board, num_solves))
+    print("num_solves = %r" % (num_solves[0],))


### PR DESCRIPTION
When it says "num_solves = 1", that means no backtracking was needed.

This shows that, for example, the default (Everest)
board requires 59 solves,
and that four of the 50 projecteuler boards
(#6, #7, #42, #43) currently require backtracking.
In bash:
  for line in $(cat collections/project_euler.txt ); do echo $line; python2 sudoku.py $line; done | grep num_solves | cat -n | grep -v "num_solves = 1"
Output is:
     6	num_solves = 6
     7	num_solves = 2
    42	num_solves = 2
    48	num_solves = 3

====================================================
Note: The above description is from the second commit b8b0660 of this pull request; the first commit 80fd632 is a previous pull request #2 which should be pulled first (if it's acceptable). I'm not sure I'm managing these dependent pull requests properly.