### PR TITLE
Implement all the simple row-column fishes. 

### DIFF
--- a/sudoku.py
+++ b/sudoku.py
@@ -22,6 +22,7 @@ groups = tuple([] for _ in range(27))
 for index, (row, col) in enumerate(product(range(9), repeat=2)):
     for displacement, rcs in enumerate((row, col, 3 * (row / 3) + col / 3)):
         groups[rcs + displacement * 9].append(index)
+rows_and_columns = groups[0:18]
 
 
 def eliminate_candidates(board, groups=groups):
@@ -35,6 +36,19 @@ def eliminate_candidates(board, groups=groups):
                     assert board[index]  # if triggered, inconsistent assignment detected
 
 
+def transpose_digits_with_cols(board):
+    # for each row and digit, answer[row * 9 + digit] will be a string
+    # representing the col positions of digit in the row
+    return [''.join('123456789'[col] for col in range(9) if digit in board[row * 9 + col])
+            for row in range(9) for digit in '123456789']
+
+
+def eliminate_rowcolumn_fish(board):
+    board[:] = transpose_digits_with_cols(board)
+    eliminate_candidates(board, rows_and_columns)
+    board[:] = transpose_digits_with_cols(board)
+
+
 num_solves = 0
 def solve(board):
     global num_solves; num_solves += 1
@@ -42,6 +56,7 @@ def solve(board):
     while 81 < candidates < prev:  # keep eliminating
         prev, candidates = candidates, sum(map(len, board))
         eliminate_candidates(board)
+        eliminate_rowcolumn_fish(board)
     if candidates == 81:  # we're done!
         return board
     lengths = map(len, board)  # otherwise, we need to search

--- a/sudoku.py
+++ b/sudoku.py
@@ -35,7 +35,9 @@ def eliminate_candidates(board, groups=groups):
                     assert board[index]  # if triggered, inconsistent assignment detected
 
 
+num_solves = 0
 def solve(board):
+    global num_solves; num_solves += 1
     candidates, prev = 1 + 9**3, 2 + 9**3
     while 81 < candidates < prev:  # keep eliminating
         prev, candidates = candidates, sum(map(len, board))
@@ -57,3 +59,4 @@ if __name__ == '__main__':
     board = list(islice([c if c.isdigit() else '123456789' for c in sudoku if c.isdigit() or c in '.0'], 81))
     line, div = ' {} {} {} | {} {} {} | {} {} {} \n', '-------+-------+-------\n'
     print (line * 3 + div + line * 3 + div + line * 3).format(*solve(board))
+    print "num_solves = %r" % (num_solves,)

--- a/sudoku.py
+++ b/sudoku.py
@@ -35,9 +35,8 @@ def eliminate_candidates(board, groups=groups):
                     assert board[index]  # if triggered, inconsistent assignment detected
 
 
-num_solves = 0
-def solve(board):
-    global num_solves; num_solves += 1
+def solve(board, num_solves):
+    num_solves[0] += 1
     candidates, prev = 1 + 9**3, 2 + 9**3
     while 81 < candidates < prev:  # keep eliminating
         eliminate_candidates(board)
@@ -48,7 +47,7 @@ def solve(board):
     pivot = lengths.index(sorted(set(lengths))[1])
     for board[pivot] in board[pivot]:
         try:
-            return solve(board[:])
+            return solve(board[:], num_solves)
         except AssertionError as e:
             pass  # try next element
     raise AssertionError('No solutions found')  # keep searching in caller
@@ -59,5 +58,6 @@ if __name__ == '__main__':
         sudoku = ' '.join(sys.argv[1:])
     board = list(islice((c if c in '123456789' else '123456789' for c in sudoku if c in '0123456789.'), 81))
     line, div = ' {} {} {} | {} {} {} | {} {} {} \n', '-------+-------+-------\n'
-    print (line * 3 + div + line * 3 + div + line * 3).format(*solve(board))
-    print "num_solves = %r" % (num_solves,)
+    num_solves = [0]
+    print (line * 3 + div + line * 3 + div + line * 3).format(*solve(board, num_solves))
+    print("num_solves = %r" % (num_solves[0],))


### PR DESCRIPTION
This implements all the following fishes, as long as the base houses
are rows and the covering houses are columns, or vice versa (in the
terminology of http://hodoku.sourceforge.net/en/tech_fishg.php):
  - x-wings (2-fish)
  - swordfish (3-fish)
  - jellyfish (4-fish)

Details:

All these simple row-column fishes are trivial to implement,
by calling the already-existing function eliminate_candidates()
on the board transformed by transposing the columns with the digits,
using only the rows and columns (not blocks) as the groups.

(There is no need to do the same with *rows*-transposed-with-digits,
since every k-fish that would be found in that way
is found as a complementary (9-k)-fish on cols-transposed-with-digits.)

This allows many more puzzles to be solved with less backtracking
or no backtracking than before.  For example, the default (Everest)
puzzle now takes only 36 calls to solve() instead of 59,
and now only one of the 50 example boards from projecteuler
still requires backtracking (4 of them required it before).
In bash:
  for line in $(cat collections/project_euler.txt ); do echo $line; python2 sudoku.py $line; done | grep num_solves | cat -n | grep -v "num_solves = 1"
Output is:
  42  num_solves = 2
Note: the reason #42 can't be done without backtracking is that it
requires pointing or claiming, which is currently not implemented
(contrary to what README.md seems to imply).

Note: The following comment which is still in README.md is evidently incorrect:
  "All these strategies [...] are, in essence, _search and backtracking_
   strategies in disguise, no more clever than brute forcing through all
   possible combinations."
As is shown in this commit, the basic fishes are actually
yet another case of the pigeonhole principle (aka "the Rule"),
and, as such, require no search-and-backtracking.
In fact, I would say that even the more exotic fishes described on the
hodoku page are still cases of the pigeonhole principle,
but they are not as easily expressed in terms of the already-written function
eliminate_candidates(), so they are not implemented here.

====================================================
Note: The above description is from the third commit 8ade71e of this pull request; the first two commits 80fd632 and b8b0660 are previous pull request #2 and pull request #5 which should be pulled first (if acceptable). I'm not sure I'm managing these dependent pull requests properly.

